### PR TITLE
Add shared random provider with optional seeding

### DIFF
--- a/Gameplay/BaseGameplay.cs
+++ b/Gameplay/BaseGameplay.cs
@@ -27,7 +27,7 @@ namespace LabyrinthExplorer.Gameplay
 
         public void Setup()
         {
-            int nameIndex = _session.Random.Next(0, Names.ListOfNames.Count - 1);
+            int nameIndex = _session.RandomProvider.Next(0, Names.ListOfNames.Count - 1);
             _session.Player.Name = Names.ListOfNames[nameIndex];
         }
 

--- a/Gameplay/GameLoop.cs
+++ b/Gameplay/GameLoop.cs
@@ -28,7 +28,7 @@ namespace GameplayNamespace
 
             _baseGameplay.BaseActions();
 
-            _session.GameplayData.RoomRef.GenerateRoom(_session.Random, _session.Console);
+            _session.GameplayData.RoomRef.GenerateRoom(_session.RandomProvider, _session.Console);
 
             _session.Console.Sleep(1250);
 

--- a/Gameplay/GameSession.cs
+++ b/Gameplay/GameSession.cs
@@ -1,21 +1,20 @@
-using System;
 using LabyrinthExplorer.Utilities;
 
 namespace LabyrinthExplorer.Gameplay
 {
     public class GameSession
     {
-        public GameSession(IConsoleService consoleService, Random? random = null)
+        public GameSession(IConsoleService consoleService, IRandomProvider? randomProvider = null)
         {
             Console = consoleService;
-            Random = random ?? new Random();
+            RandomProvider = randomProvider ?? new RandomProvider();
             Player = new Player(Console);
             GameplayData = new GameplayData();
         }
 
         public IConsoleService Console { get; }
 
-        public Random Random { get; }
+        public IRandomProvider RandomProvider { get; }
 
         public Player Player { get; }
 
@@ -23,8 +22,8 @@ namespace LabyrinthExplorer.Gameplay
 
         public static GameSession CreateDefault(int? seed = null, IConsoleService? console = null)
         {
-            var random = seed.HasValue ? new Random(seed.Value) : new Random();
-            return new GameSession(console ?? new SystemConsoleService(), random);
+            var randomProvider = new RandomProvider(seed);
+            return new GameSession(console ?? new SystemConsoleService(), randomProvider);
         }
     }
 }

--- a/Handlers/SelectionHandler.cs
+++ b/Handlers/SelectionHandler.cs
@@ -123,13 +123,13 @@ namespace LabyrinthExplorer.Handlers
                 switch (input)
                 {
                     case "Item":
-                        index = _session.Random.Next(0, BaseCardList.ItemCards.Count - 1);
+                        index = _session.RandomProvider.Next(0, BaseCardList.ItemCards.Count - 1);
                         _session.Player.Inventory.Add(BaseCardList.ItemCards[index]);
                         _baseGameplay.Printf("~{Added an item to your inventory}~.\n");
                         _baseGameplay.Printf($"~{BaseCardList.ItemCards[index].Name}~.\n");
                         break;
                     case "Omen":
-                        index = _session.Random.Next(0, BaseCardList.OmenCards.Count - 1);
+                        index = _session.RandomProvider.Next(0, BaseCardList.OmenCards.Count - 1);
                         _session.Player.Inventory.Add(BaseCardList.OmenCards[index]);
                         _baseGameplay.Printf("~{Added an Omen card to your inventory}~.\n");
                         _baseGameplay.Printf($"~{BaseCardList.OmenCards[index].Name}~.\n");

--- a/Handlers/Take.cs
+++ b/Handlers/Take.cs
@@ -47,7 +47,7 @@ namespace Handlers
 
         private Card NewOmenCard()
         {
-            var rndOmenIndex = _session.Random.Next(0, BaseCardList.OmenCards.Count - 1);
+            var rndOmenIndex = _session.RandomProvider.Next(0, BaseCardList.OmenCards.Count - 1);
             Card omenCard = BaseCardList.OmenCards[rndOmenIndex];
             _session.Player.Inventory.Add(omenCard);
             _session.GameplayData.RoomRef.HasCard = false;
@@ -57,7 +57,7 @@ namespace Handlers
 
         private Card NewItemCard()
         {
-            var rndItemIndex = _session.Random.Next(0, BaseCardList.ItemCards.Count - 1);
+            var rndItemIndex = _session.RandomProvider.Next(0, BaseCardList.ItemCards.Count - 1);
             Card itemCard = BaseCardList.ItemCards[rndItemIndex];
             _session.Player.Inventory.Add(itemCard);
             _session.GameplayData.RoomRef.HasCard = false;

--- a/README.md
+++ b/README.md
@@ -2,3 +2,11 @@
 A text based game based loosely off the board game: Betrayal at House on the Hill.
 
 You can find the packaged game on [itch.io](https://alkain-studios-llc.itch.io/cs-labyrinth-explorer) available for Windows, Linux, and Mac.
+
+## Deterministic runs for testing
+
+`GameSession` now uses a shared random number generator, which can be seeded for predictable behavior during tests. Pass a seed to `GameSession.CreateDefault` (or construct your own `RandomProvider`) to reproduce the same room layouts and card draws between runs:
+
+```csharp
+var session = GameSession.CreateDefault(seed: 1234);
+```

--- a/Room.cs
+++ b/Room.cs
@@ -10,7 +10,7 @@ namespace LabyrinthExplorer
     {
         static Dictionary<string, DoorWayType> mDoor { get; set; }
         [Obsolete("Use GenerateRoom instead")]
-        public void CreateRoom()
+        public void CreateRoom(IRandomProvider randomProvider)
         {
             if (RoomID < uint.MaxValue - 1)
                 RoomID++;
@@ -19,10 +19,10 @@ namespace LabyrinthExplorer
 
             Doors = new Dictionary<string, DoorWayType>
             {
-                { "North", GenerateDoorType(new Random()) },
-                { "East", GenerateDoorType(new Random()) },
-                { "West", GenerateDoorType(new Random()) },
-                { "South", GenerateDoorType(new Random()) }
+                { "North", GenerateDoorType(randomProvider) },
+                { "East", GenerateDoorType(randomProvider) },
+                { "West", GenerateDoorType(randomProvider) },
+                { "South", GenerateDoorType(randomProvider) }
             };
 
             if (!Doors.ContainsValue(DoorWayType.Open))
@@ -38,10 +38,10 @@ namespace LabyrinthExplorer
             s += "----------------------------------------------------\n";
             GameConsole.Printf(s);
 
-            Card = RoomID > 0 ? GenerateCardType(new Random()) : CardType.None;
+            Card = RoomID > 0 ? GenerateCardType(randomProvider) : CardType.None;
         }
 
-        public void GenerateRoom(Random random, IConsoleService console)
+        public void GenerateRoom(IRandomProvider randomProvider, IConsoleService console)
         {
             if (RoomID < uint.MaxValue - 1)
                 RoomID++;
@@ -56,18 +56,18 @@ namespace LabyrinthExplorer
                 { "South", DoorWayType.None }
             };
 
-            int doorCount = random.Next(1, 4);
+            int doorCount = randomProvider.Next(1, 4);
             List<string> directions = new() { "North", "East", "West", "South" };
 
-            string randomDirection = directions[random.Next(directions.Count)];
+            string randomDirection = directions[randomProvider.Next(directions.Count)];
             Doors[randomDirection] = DoorWayType.Open;
             directions.Remove(randomDirection);
             doorCount--;
 
             while (doorCount > 0 && directions.Count > 0)
             {
-                randomDirection = directions[random.Next(directions.Count)];
-                Doors[randomDirection] = (DoorWayType)random.Next(0, 3);
+                randomDirection = directions[randomProvider.Next(directions.Count)];
+                Doors[randomDirection] = (DoorWayType)randomProvider.Next(0, 3);
                 directions.Remove(randomDirection);
                 doorCount--;
             }
@@ -82,7 +82,7 @@ namespace LabyrinthExplorer
             roomInfo += "----------------------------------------------------\n";
             console.Write(roomInfo);
 
-            Card = RoomID > 0 ? GenerateCardType(random) : CardType.None;
+            Card = RoomID > 0 ? GenerateCardType(randomProvider) : CardType.None;
         }
 
 
@@ -118,14 +118,14 @@ namespace LabyrinthExplorer
             return roomDesc;
         }
 
-        public static DoorWayType GenerateDoorType(Random random)
+        public static DoorWayType GenerateDoorType(IRandomProvider randomProvider)
         {
-            return (DoorWayType)random.Next(-1, 3);
+            return (DoorWayType)randomProvider.Next(-1, 3);
         }
 
-        public static CardType GenerateCardType(Random random)
+        public static CardType GenerateCardType(IRandomProvider randomProvider)
         {
-            return (CardType)random.Next(0, 4);
+            return (CardType)randomProvider.Next(0, 4);
         }
 
 

--- a/Utilities/IRandomProvider.cs
+++ b/Utilities/IRandomProvider.cs
@@ -1,0 +1,38 @@
+using System;
+
+namespace LabyrinthExplorer.Utilities
+{
+    public interface IRandomProvider
+    {
+        int Next(int maxValue);
+
+        int Next(int minValue, int maxValue);
+    }
+
+    public class RandomProvider : IRandomProvider
+    {
+        private readonly Random _random;
+
+        public RandomProvider(int? seed = null)
+        {
+            _random = seed.HasValue ? new Random(seed.Value) : new Random();
+        }
+
+        public RandomProvider(Random random)
+        {
+            _random = random ?? throw new ArgumentNullException(nameof(random));
+        }
+
+        public int Next(int maxValue)
+        {
+            return _random.Next(maxValue);
+        }
+
+        public int Next(int minValue, int maxValue)
+        {
+            return _random.Next(minValue, maxValue);
+        }
+
+        public Random Instance => _random;
+    }
+}


### PR DESCRIPTION
## Summary
- introduce a reusable random provider injected via GameSession
- update room generation and card selection to use the shared generator
- document how to seed the game for deterministic runs

## Testing
- dotnet build *(not run: dotnet CLI unavailable in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693f846898548332a72c8bcbdfa67910)