### PR TITLE
Refactor input handling and add tests

### DIFF
--- a/Gameplay/BaseGameplay.cs
+++ b/Gameplay/BaseGameplay.cs
@@ -1,10 +1,8 @@
 using System;
 using System.Collections.Generic;
-using System.Text;
 using Enums;
 using LabyrinthExplorer.Data;
 using LabyrinthExplorer.Utilities;
-using Utilities;
 
 namespace LabyrinthExplorer.Gameplay
 {
@@ -71,13 +69,13 @@ namespace LabyrinthExplorer.Gameplay
         {
             var actions = new List<string>
             {
-                "(L)eave/(Q)uit",
-                "Look",
-                "(N)orth",
-                "(E)ast",
-                "(W)est",
-                "(S)outh",
-                "(I)nventory"
+                "quit",
+                "look",
+                "north",
+                "east",
+                "west",
+                "south",
+                "inventory"
             };
 
             if (_session.GameplayData.RoomRef.bSearched == false)
@@ -148,22 +146,18 @@ namespace LabyrinthExplorer.Gameplay
 
         public string ReadInput()
         {
-            StringBuilder sb = new();
+            string renderedActions = CommandRegistry.FormatActions(_session.GameplayData.UserActions);
 
-            foreach (string action in _session.GameplayData.UserActions)
-            {
-                sb.Append($"[{action}]");
-            }
-
-            Printf($"\n[Actions ~|{sb}|~ ]");
+            Printf($"\n[Actions ~|{renderedActions}|~ ]");
 
             Printf("\n#>| ");
             var userIn = _console.ReadLine() ?? string.Empty;
-            _session.GameplayData.UserInput.Prop = userIn;
+            var normalized = CommandRegistry.Normalize(userIn);
+            _session.GameplayData.UserInput.Prop = normalized;
 
             _console.Sleep(500);
 
-            return Utils.Capitalize(_session.GameplayData.UserInput.Prop.ToLower());
+            return normalized;
         }
 
         public void Printf(string s) => _console.Write(s);

--- a/Handlers/Menu.cs
+++ b/Handlers/Menu.cs
@@ -26,53 +26,52 @@ namespace Handlers
         {
             string version = Assembly.GetExecutingAssembly().GetName().Version.ToString();
 
-            _session.GameplayData.UserActions = new List<string>() { "New Game", "Load", "Quit" };
-            StringBuilder sb = new StringBuilder();
-            _session.GameplayData.UserActions.ForEach(action => sb.Append($"\n [{action}]"));
+            bool running = true;
 
-            Printf("\n\n");
-            Printf($"\n[  Version: {version}  ]\n");
-            Printf("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n");
-            Printf("~~~~~~~~~~ Labyrinth Explorer ~~~~~~~~~~\n");
-            Printf("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n\n");
-            Printf("~~~~~~~~~~~~~~~~~~~~~\n");
-            Printf("~~~~~ Main Menu ~~~~~\n");
-            Printf("~~~~~~~~~~~~~~~~~~~~~");
-            Printf($"{sb.ToString()}\n");
-            Printf("\n#>| ");
-
-            _session.GameplayData.Input = _session.Console.ReadLine();
-            _session.GameplayData.Input = _session.GameplayData.Input.ToLower();
-
-            switch (_session.GameplayData.Input)
+            while (running)
             {
-                case "n":
-                case "new":
-                case "new game":
-                    _session.Console.Clear();
-                    _gameplay.NewGame();
-                    break;
-                case "l":
-                case "load":
-                case "load game":
-                    Printf("\n\nThis option is not ready yet.");
-                    Printf("\n#>| ");
-                    _session.Console.ReadKey(true);
-                    _session.Console.Clear();
-                    _session.Console.Sleep(500);
-                    Run();
-                    break;
-                case "e":
-                case "q":
-                case "exit":
-                case "quit":
-                    _gameplay.Quit();
-                    break;
-                default:
-                    _session.Console.Clear();
-                    Run();
-                    break;
+                _session.GameplayData.UserActions = new List<string>() { "new", "load", "quit" };
+                StringBuilder sb = new StringBuilder();
+                sb.Append(CommandRegistry.FormatActions(_session.GameplayData.UserActions));
 
+                Printf("\n\n");
+                Printf($"\n[  Version: {version}  ]\n");
+                Printf("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n");
+                Printf("~~~~~~~~~~ Labyrinth Explorer ~~~~~~~~~~\n");
+                Printf("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n\n");
+                Printf("~~~~~~~~~~~~~~~~~~~~~\n");
+                Printf("~~~~~ Main Menu ~~~~~\n");
+                Printf("~~~~~~~~~~~~~~~~~~~~~");
+                Printf($"{sb}\n");
+                Printf("\n#>| ");
+
+                string input = _session.Console.ReadLine();
+
+                if (!CommandRegistry.TryMapMenu(input, out var command))
+                {
+                    _session.Console.Clear();
+                    continue;
+                }
+
+                switch (command)
+                {
+                    case "new":
+                        _session.Console.Clear();
+                        _gameplay.NewGame();
+                        running = false;
+                        break;
+                    case "load":
+                        Printf("\n\nThis option is not ready yet.");
+                        Printf("\n#>| ");
+                        _session.Console.ReadKey(true);
+                        _session.Console.Clear();
+                        _session.Console.Sleep(500);
+                        break;
+                    case "quit":
+                        _gameplay.Quit();
+                        running = false;
+                        break;
+                }
             }
         }
 

--- a/Handlers/Take.cs
+++ b/Handlers/Take.cs
@@ -17,9 +17,9 @@ namespace Handlers
 
         public void DrawCard(CardType cardType)
         {
-            if (_session.GameplayData.UserActions.Contains("Take"))
+            if (_session.GameplayData.UserActions.Contains("take"))
             {
-                _session.GameplayData.UserActions.Remove("Take");
+                _session.GameplayData.UserActions.Remove("take");
 
                 switch (cardType)
                 {

--- a/LabyrinthExplorer.Tests/CommandRegistryTests.cs
+++ b/LabyrinthExplorer.Tests/CommandRegistryTests.cs
@@ -1,0 +1,28 @@
+using LabyrinthExplorer.Utilities;
+using Xunit;
+
+namespace LabyrinthExplorer.Tests
+{
+    public class CommandRegistryTests
+    {
+        [Theory]
+        [InlineData(" N ", "north")]
+        [InlineData("East", "east")]
+        [InlineData("l", "quit")]
+        [InlineData("Inventory", "inventory")]
+        public void MapsGameplayAliases(string input, string expected)
+        {
+            Assert.True(CommandRegistry.TryMapGameplay(input, out var command));
+            Assert.Equal(expected, command);
+        }
+
+        [Theory]
+        [InlineData("NEW GAME", "new")]
+        [InlineData(" q", "quit")]
+        public void MapsMenuAliases(string input, string expected)
+        {
+            Assert.True(CommandRegistry.TryMapMenu(input, out var command));
+            Assert.Equal(expected, command);
+        }
+    }
+}

--- a/LabyrinthExplorer.Tests/LabyrinthExplorer.Tests.csproj
+++ b/LabyrinthExplorer.Tests/LabyrinthExplorer.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="xunit" Version="2.7.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.8">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\LabyrinthExplorer.csproj" />
+  </ItemGroup>
+</Project>

--- a/LabyrinthExplorer.Tests/SelectionHandlerTests.cs
+++ b/LabyrinthExplorer.Tests/SelectionHandlerTests.cs
@@ -1,0 +1,73 @@
+using System.Collections.Generic;
+using Enums;
+using GameplayNamespace;
+using LabyrinthExplorer;
+using LabyrinthExplorer.Gameplay;
+using LabyrinthExplorer.Handlers;
+using LabyrinthExplorer.Tests.TestUtilities;
+using LabyrinthExplorer.Utilities;
+using Xunit;
+
+namespace LabyrinthExplorer.Tests
+{
+    public class SelectionHandlerTests
+    {
+        [Fact]
+        public void Actions_ExitsAfterConfirmedQuit()
+        {
+            var console = new FakeConsoleService(new[] { "quit", "yes" });
+            var session = new GameSession(console, new StaticRandomProvider());
+            session.GameplayData.RoomRef = new Room
+            {
+                Doors = new Dictionary<string, DoorWayType>
+                {
+                    { "North", DoorWayType.Blocked },
+                    { "East", DoorWayType.Blocked },
+                    { "West", DoorWayType.Blocked },
+                    { "South", DoorWayType.Blocked },
+                },
+                bSearched = false,
+                HasCard = false,
+                Card = CardType.None,
+            };
+            session.GameplayData.RoomCard = CardType.None;
+
+            var gameplay = new BaseGameplay(session);
+            var gameLoop = new GameLoop(session, gameplay);
+            var handler = new SelectionHandler(session, gameplay, gameLoop);
+
+            var menuReturnCount = 0;
+            handler.RegisterMenu(() => menuReturnCount++);
+
+            handler.Actions();
+
+            Assert.Equal(0, console.RemainingInputs);
+            Assert.Equal(1, menuReturnCount);
+        }
+
+        [Fact]
+        public void BaseActions_UsesCanonicalCommands()
+        {
+            var console = new FakeConsoleService(new[] { string.Empty });
+            var session = new GameSession(console, new StaticRandomProvider());
+            session.GameplayData.RoomRef = new Room
+            {
+                Doors = new Dictionary<string, DoorWayType>(),
+                bSearched = false,
+                HasCard = true,
+                Card = CardType.Item,
+            };
+            session.GameplayData.RoomCard = CardType.Item;
+
+            var gameplay = new BaseGameplay(session);
+
+            gameplay.BaseActions();
+
+            var actions = session.GameplayData.UserActions;
+            Assert.Contains("quit", actions);
+            Assert.Contains("search", actions);
+            Assert.Contains("take", actions);
+            Assert.DoesNotContain("(N)orth", actions);
+        }
+    }
+}

--- a/LabyrinthExplorer.Tests/TestUtilities/FakeConsoleService.cs
+++ b/LabyrinthExplorer.Tests/TestUtilities/FakeConsoleService.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using LabyrinthExplorer.Utilities;
+
+namespace LabyrinthExplorer.Tests.TestUtilities
+{
+    public class FakeConsoleService : IConsoleService
+    {
+        private readonly Queue<string> _inputs;
+
+        public FakeConsoleService(IEnumerable<string> inputs)
+        {
+            _inputs = new Queue<string>(inputs);
+        }
+
+        public StringBuilder Output { get; } = new();
+
+        public int ReadKeyCount { get; private set; }
+
+        public int RemainingInputs => _inputs.Count;
+
+        public void Write(string text) => Output.Append(text);
+
+        public void WriteLine(string text) => Output.AppendLine(text);
+
+        public string ReadLine()
+        {
+            if (_inputs.Count == 0)
+            {
+                throw new InvalidOperationException("No more scripted input available.");
+            }
+
+            return _inputs.Dequeue();
+        }
+
+        public void Clear() => Output.Clear();
+
+        public void Sleep(int milliseconds)
+        {
+        }
+
+        public ConsoleKeyInfo ReadKey(bool intercept)
+        {
+            ReadKeyCount++;
+            return new ConsoleKeyInfo(' ', ConsoleKey.Spacebar, false, false, false);
+        }
+    }
+}

--- a/LabyrinthExplorer.Tests/TestUtilities/StaticRandomProvider.cs
+++ b/LabyrinthExplorer.Tests/TestUtilities/StaticRandomProvider.cs
@@ -1,0 +1,18 @@
+using LabyrinthExplorer.Utilities;
+
+namespace LabyrinthExplorer.Tests.TestUtilities
+{
+    public class StaticRandomProvider : IRandomProvider
+    {
+        private readonly int _value;
+
+        public StaticRandomProvider(int value = 0)
+        {
+            _value = value;
+        }
+
+        public int Next(int maxValue) => _value % maxValue;
+
+        public int Next(int minValue, int maxValue) => minValue;
+    }
+}

--- a/LabyrinthExplorer.sln
+++ b/LabyrinthExplorer.sln
@@ -5,17 +5,23 @@ VisualStudioVersion = 16.0.30320.27
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LabyrinthExplorer", "LabyrinthExplorer.csproj", "{212E4607-C179-4896-86D4-9D1F4D1F5DC4}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LabyrinthExplorer.Tests", "LabyrinthExplorer.Tests\\LabyrinthExplorer.Tests.csproj", "{B2F3E2E3-6E1A-472D-8F7E-7C5E0B123456}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{212E4607-C179-4896-86D4-9D1F4D1F5DC4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{212E4607-C179-4896-86D4-9D1F4D1F5DC4}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{212E4607-C179-4896-86D4-9D1F4D1F5DC4}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{212E4607-C179-4896-86D4-9D1F4D1F5DC4}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+                {212E4607-C179-4896-86D4-9D1F4D1F5DC4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {212E4607-C179-4896-86D4-9D1F4D1F5DC4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {B2F3E2E3-6E1A-472D-8F7E-7C5E0B123456}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {B2F3E2E3-6E1A-472D-8F7E-7C5E0B123456}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {212E4607-C179-4896-86D4-9D1F4D1F5DC4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {212E4607-C179-4896-86D4-9D1F4D1F5DC4}.Release|Any CPU.Build.0 = Release|Any CPU
+                {B2F3E2E3-6E1A-472D-8F7E-7C5E0B123456}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {B2F3E2E3-6E1A-472D-8F7E-7C5E0B123456}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection

--- a/Utilities/CommandRegistry.cs
+++ b/Utilities/CommandRegistry.cs
@@ -1,0 +1,117 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace LabyrinthExplorer.Utilities
+{
+    public static class CommandRegistry
+    {
+        private static readonly IReadOnlyDictionary<string, string> GameplayAliases =
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["n"] = "north",
+                ["north"] = "north",
+                ["e"] = "east",
+                ["east"] = "east",
+                ["w"] = "west",
+                ["west"] = "west",
+                ["s"] = "south",
+                ["south"] = "south",
+                ["look"] = "look",
+                ["search"] = "search",
+                ["take"] = "take",
+                ["use"] = "use",
+                ["inventory"] = "inventory",
+                ["i"] = "inventory",
+                ["q"] = "quit",
+                ["quit"] = "quit",
+                ["l"] = "quit",
+                ["leave"] = "quit",
+                ["dev"] = "dev",
+            };
+
+        private static readonly IReadOnlyDictionary<string, string> MenuAliases =
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["n"] = "new",
+                ["new"] = "new",
+                ["new game"] = "new",
+                ["l"] = "load",
+                ["load"] = "load",
+                ["load game"] = "load",
+                ["q"] = "quit",
+                ["quit"] = "quit",
+                ["e"] = "quit",
+                ["exit"] = "quit",
+            };
+
+        private static readonly IReadOnlyDictionary<string, string> DevAliases =
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["item"] = "item",
+                ["omen"] = "omen",
+                ["leave"] = "leave",
+                ["back"] = "leave",
+            };
+
+        private static readonly IReadOnlyDictionary<string, string> ConfirmationAliases =
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["y"] = "yes",
+                ["yes"] = "yes",
+                ["n"] = "no",
+                ["no"] = "no",
+            };
+
+        private static readonly IReadOnlyDictionary<string, string> DisplayNames =
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["quit"] = "(q)uit/(l)eave",
+                ["look"] = "look",
+                ["north"] = "(n)orth",
+                ["east"] = "(e)ast",
+                ["west"] = "(w)est",
+                ["south"] = "(s)outh",
+                ["inventory"] = "(i)nventory",
+                ["search"] = "search",
+                ["take"] = "take",
+                ["use"] = "use",
+                ["dev"] = "dev",
+                ["new"] = "new game",
+                ["load"] = "load",
+                ["item"] = "item",
+                ["omen"] = "omen",
+                ["leave"] = "leave",
+                ["yes"] = "yes",
+                ["no"] = "no",
+            };
+
+        public static string Normalize(string? input) => (input ?? string.Empty).Trim().ToLowerInvariant();
+
+        public static bool TryMapGameplay(string input, out string command) =>
+            GameplayAliases.TryGetValue(Normalize(input), out command!);
+
+        public static bool TryMapMenu(string input, out string command) =>
+            MenuAliases.TryGetValue(Normalize(input), out command!);
+
+        public static bool TryMapDev(string input, out string command) =>
+            DevAliases.TryGetValue(Normalize(input), out command!);
+
+        public static bool TryMapConfirmation(string input, out string command) =>
+            ConfirmationAliases.TryGetValue(Normalize(input), out command!);
+
+        public static string FormatActions(IEnumerable<string> actions)
+        {
+            var sb = new StringBuilder();
+            foreach (var action in actions)
+            {
+                sb.Append($"[{GetDisplayName(action)}]");
+            }
+
+            return sb.ToString();
+        }
+
+        public static string GetDisplayName(string command) =>
+            DisplayNames.TryGetValue(command, out var label) ? label : command;
+    }
+}


### PR DESCRIPTION
## Summary
- refactor menu and gameplay input flows to use iterative loops with explicit exit handling
- normalize command handling through a shared registry and unified action rendering
- add unit tests covering command parsing and quit behavior

## Testing
- Not run (dotnet CLI unavailable in the environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693f85bb1a1c8332bc7d4e950aa322d2)