### PR TITLE
Ensure room card state is tracked for actions

### DIFF
--- a/Gameplay/BaseGameplay.cs
+++ b/Gameplay/BaseGameplay.cs
@@ -79,10 +79,10 @@ namespace LabyrinthExplorer.Gameplay
             };
 
             if (_session.GameplayData.RoomRef.bSearched == false)
-                actions.Add("Search");
+                actions.Add("search");
 
             if (_session.GameplayData.RoomRef.HasCard)
-                actions.Add("Take");
+                actions.Add("take");
 
             _session.GameplayData.UserActions = actions;
         }

--- a/Gameplay/GameLoop.cs
+++ b/Gameplay/GameLoop.cs
@@ -26,9 +26,10 @@ namespace GameplayNamespace
             _session.Console.Sleep(1000);
             _session.GameplayData.RoomRef = new Room();
 
-            _baseGameplay.BaseActions();
-
             _session.GameplayData.RoomRef.GenerateRoom(_session.RandomProvider, _session.Console);
+            _session.GameplayData.RoomCard = _session.GameplayData.RoomRef.Card;
+
+            _baseGameplay.BaseActions();
 
             _session.Console.Sleep(1250);
 

--- a/Gameplay/GameplayData.cs
+++ b/Gameplay/GameplayData.cs
@@ -11,7 +11,6 @@ namespace LabyrinthExplorer.Gameplay
         public Room RoomRef { get; set; }
         [Obsolete("Currently being refactored")]
         public int RoomCount { get; set; }
-        [Obsolete("Currently being refactored")]
         public CardType RoomCard { get; set; }
         public List<string> UserActions { get; set; }
         public List<Card> CardList { get; set; }

--- a/LabyrinthExplorer.Tests/BaseGameplayTests.cs
+++ b/LabyrinthExplorer.Tests/BaseGameplayTests.cs
@@ -1,0 +1,60 @@
+using Enums;
+using GameplayNamespace;
+using LabyrinthExplorer;
+using LabyrinthExplorer.Gameplay;
+using LabyrinthExplorer.Tests.TestUtilities;
+using Xunit;
+
+namespace LabyrinthExplorer.Tests
+{
+    public class BaseGameplayTests
+    {
+        [Fact]
+        public void BaseActions_AddsTake_WhenRoomHasCard()
+        {
+            var session = new GameSession(new FakeConsoleService([]), new StaticRandomProvider());
+            session.GameplayData.RoomRef = new Room
+            {
+                HasCard = true,
+            };
+
+            var gameplay = new BaseGameplay(session);
+
+            gameplay.BaseActions();
+
+            Assert.Contains("take", session.GameplayData.UserActions);
+        }
+
+        [Fact]
+        public void BaseActions_OmitsTake_WhenRoomHasNoCard()
+        {
+            var session = new GameSession(new FakeConsoleService([]), new StaticRandomProvider());
+            session.GameplayData.RoomRef = new Room
+            {
+                HasCard = false,
+            };
+
+            var gameplay = new BaseGameplay(session);
+
+            gameplay.BaseActions();
+
+            Assert.DoesNotContain("take", session.GameplayData.UserActions);
+        }
+
+        [Fact]
+        public void ExploreNewRoom_SetsRoomCardAndActionsFromGeneration()
+        {
+            var random = new SequenceRandomProvider(new[] { 0, 0, 3 });
+            var session = new GameSession(new FakeConsoleService([]), random);
+            var gameplay = new BaseGameplay(session);
+            var gameLoop = new GameLoop(session, gameplay);
+
+            gameLoop.ExploreNewRoom();
+
+            Assert.Equal(CardType.Item, session.GameplayData.RoomRef.Card);
+            Assert.True(session.GameplayData.RoomRef.HasCard);
+            Assert.Equal(session.GameplayData.RoomRef.Card, session.GameplayData.RoomCard);
+            Assert.Contains("take", session.GameplayData.UserActions);
+        }
+    }
+}

--- a/LabyrinthExplorer.Tests/TestUtilities/SequenceRandomProvider.cs
+++ b/LabyrinthExplorer.Tests/TestUtilities/SequenceRandomProvider.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Generic;
+using LabyrinthExplorer.Utilities;
+
+namespace LabyrinthExplorer.Tests.TestUtilities
+{
+    public class SequenceRandomProvider : IRandomProvider
+    {
+        private readonly Queue<int> _values;
+
+        public SequenceRandomProvider(IEnumerable<int> values)
+        {
+            _values = new Queue<int>(values);
+        }
+
+        public int Next(int maxValue)
+        {
+            var next = _values.Count > 0 ? _values.Dequeue() : 0;
+            return Math.Abs(next) % Math.Max(1, maxValue);
+        }
+
+        public int Next(int minValue, int maxValue)
+        {
+            var next = _values.Count > 0 ? _values.Dequeue() : minValue;
+            var range = Math.Max(1, maxValue - minValue);
+            return minValue + Math.Abs(next) % range;
+        }
+    }
+}

--- a/Room.cs
+++ b/Room.cs
@@ -39,6 +39,7 @@ namespace LabyrinthExplorer
             GameConsole.Printf(s);
 
             Card = RoomID > 0 ? GenerateCardType(randomProvider) : CardType.None;
+            HasCard = Card != CardType.None;
         }
 
         public void GenerateRoom(IRandomProvider randomProvider, IConsoleService console)
@@ -83,6 +84,7 @@ namespace LabyrinthExplorer
             console.Write(roomInfo);
 
             Card = RoomID > 0 ? GenerateCardType(randomProvider) : CardType.None;
+            HasCard = Card != CardType.None;
         }
 
 


### PR DESCRIPTION
## Summary
- align room generation so card presence and HasCard stay in sync and propagate to gameplay data
- update base gameplay actions to use canonical commands and reflect current room card availability
- add deterministic tests covering room generation flags and action lists

## Testing
- Not run (dotnet CLI not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694042fafd5c83328d64ef08358f849c)