### PR TITLE
Add player state serialization and lifecycle management

### DIFF
--- a/Gameplay/GameSession.cs
+++ b/Gameplay/GameSession.cs
@@ -1,14 +1,17 @@
+using System;
 using LabyrinthExplorer.Utilities;
 
 namespace LabyrinthExplorer.Gameplay
 {
-    public class GameSession
+    public class GameSession : IDisposable
     {
-        public GameSession(IConsoleService consoleService, IRandomProvider? randomProvider = null)
+        private bool _disposed;
+
+        public GameSession(IConsoleService consoleService, IRandomProvider? randomProvider = null, PlayerData? playerData = null)
         {
             Console = consoleService;
             RandomProvider = randomProvider ?? new RandomProvider();
-            Player = new Player(Console);
+            Player = new Player(Console, playerData ?? new PlayerData());
             GameplayData = new GameplayData();
         }
 
@@ -20,10 +23,46 @@ namespace LabyrinthExplorer.Gameplay
 
         public GameplayData GameplayData { get; }
 
+        public PlayerData CapturePlayerState()
+        {
+            return Player.ToData();
+        }
+
+        public void RestorePlayerState(PlayerData playerData)
+        {
+            Player.LoadFromData(playerData);
+        }
+
         public static GameSession CreateDefault(int? seed = null, IConsoleService? console = null)
         {
             var randomProvider = new RandomProvider(seed);
             return new GameSession(console ?? new SystemConsoleService(), randomProvider);
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            if (disposing)
+            {
+                Player.Dispose();
+            }
+
+            _disposed = true;
+        }
+
+        ~GameSession()
+        {
+            Dispose(false);
         }
     }
 }

--- a/Player.cs
+++ b/Player.cs
@@ -1,23 +1,30 @@
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using LabyrinthExplorer.Data;
 using LabyrinthExplorer.Utilities;
 using Utilities;
 
 namespace LabyrinthExplorer
 {
-    public class Player : PlayerData
+    public class Player : IDisposable
     {
         private readonly IConsoleService _console;
-        internal Notifier<int> _Sanity = new Notifier<int>();
+        private readonly Notifier<int> _Sanity = new Notifier<int>();
+        private bool _disposed;
 
         public Player(IConsoleService console)
+            : this(console, new PlayerData())
+        {
+        }
+
+        public Player(IConsoleService console, PlayerData state)
         {
             _console = console;
-            Name = string.Empty;
-            Sanity = 10;
-
-            Inventory = new List<Item>();
             _Sanity.PropertyChanged += Score_PropertyChanged;
+            Inventory = new List<Item>();
+
+            LoadFromData(state);
         }
 
         public string Name { get; set; }
@@ -30,9 +37,87 @@ namespace LabyrinthExplorer
 
         public List<Item> Inventory { get; private set; }
 
+        public PlayerData ToData()
+        {
+            return new PlayerData
+            {
+                Name = Name,
+                Sanity = Sanity,
+                Inventory = CloneInventory()
+            };
+        }
+
+        public void LoadFromData(PlayerData state)
+        {
+            if (state == null)
+            {
+                throw new ArgumentNullException(nameof(state));
+            }
+
+            Name = state.Name ?? string.Empty;
+            ReplaceInventory(state.Inventory ?? new List<Item>());
+            SetSanitySilently(state.Sanity);
+        }
+
         private void Score_PropertyChanged(object sender, PropertyChangedEventArgs e)
         {
             _console.Write($"Sanity changed to: {Sanity}");
+        }
+
+        private void SetSanitySilently(int sanity)
+        {
+            _Sanity.PropertyChanged -= Score_PropertyChanged;
+            _Sanity.Prop = sanity;
+            _Sanity.PropertyChanged += Score_PropertyChanged;
+        }
+
+        private List<Item> CloneInventory()
+        {
+            var clone = new List<Item>();
+
+            foreach (var item in Inventory)
+            {
+                clone.Add(CloneItem(item));
+            }
+
+            return clone;
+        }
+
+        private static Item CloneItem(Item item)
+        {
+            return item switch
+            {
+                Card card => new Card
+                {
+                    _CardType = card._CardType,
+                    Name = card.Name,
+                    Description = card.Description,
+                    ID = card.ID
+                },
+                Weapon weapon => new Weapon
+                {
+                    _WeaponType = weapon._WeaponType,
+                    Name = weapon.Name,
+                    Description = weapon.Description,
+                    ID = weapon.ID
+                },
+                _ => new Item
+                {
+                    Name = item.Name,
+                    Description = item.Description,
+                    ID = item.ID
+                }
+            };
+        }
+
+        private void ReplaceInventory(IEnumerable<Item> items)
+        {
+            Inventory = new List<Item>();
+
+            foreach (var item in items)
+            {
+                Inventory.Add(CloneItem(item));
+            }
         }
 
         public void ShowInventory()
@@ -44,9 +129,41 @@ namespace LabyrinthExplorer
         {
             return $"{Name}";
         }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            if (disposing)
+            {
+                _Sanity.PropertyChanged -= Score_PropertyChanged;
+                _Sanity.Dispose();
+            }
+
+            _disposed = true;
+        }
+
+        ~Player()
+        {
+            Dispose(false);
+        }
     }
 
     public class PlayerData
     {
+        public string Name { get; set; } = string.Empty;
+
+        public int Sanity { get; set; } = 10;
+
+        public List<Item> Inventory { get; set; } = new List<Item>();
     }
 }


### PR DESCRIPTION
## Summary
- convert Player into a disposable instance with lifecycle-managed sanity notifications and cloned inventory state
- add serialization and restore helpers so player data can be captured or rehydrated for saves
- let sessions accept and return player data, disposing player resources with the session

## Testing
- Not run (dotnet CLI not available in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6940453fc4c88332af0117339730bcc6)