### PR TITLE
Add builder to compose game dependencies

### DIFF
--- a/Infrastructure/GameBuilder.cs
+++ b/Infrastructure/GameBuilder.cs
@@ -1,0 +1,137 @@
+using System;
+using GameplayNamespace;
+using Handlers;
+using LabyrinthExplorer.Gameplay;
+using LabyrinthExplorer.Handlers;
+using LabyrinthExplorer.Utilities;
+
+namespace LabyrinthExplorer.Infrastructure
+{
+    public class GameBuilderOptions
+    {
+        public IConsoleService? ConsoleService { get; set; }
+
+        public IRandomProvider? RandomProvider { get; set; }
+
+        public IGameStateStore? StateStore { get; set; }
+
+        public PlayerData? PlayerData { get; set; }
+
+        public int? Seed { get; set; }
+    }
+
+    public static class GameBuilder
+    {
+        public static GameApplication Build(GameBuilderOptions? options = null)
+        {
+            options ??= new GameBuilderOptions();
+
+            var console = options.ConsoleService ?? new SystemConsoleService();
+            var randomProvider = options.RandomProvider ?? new RandomProvider(options.Seed);
+            var playerData = options.PlayerData ?? options.StateStore?.LoadPlayer() ?? new PlayerData();
+
+            var session = new GameSession(console, randomProvider, playerData);
+            var gameplay = new BaseGameplay(session);
+            var gameLoop = new GameLoop(session, gameplay);
+            var selectionHandler = new SelectionHandler(session, gameplay, gameLoop);
+
+            var application = new GameApplication(session, gameplay, gameLoop, selectionHandler, options.StateStore);
+            application.Configure();
+
+            return application;
+        }
+    }
+
+    public class GameApplication : IDisposable
+    {
+        private readonly GameSession _session;
+        private readonly BaseGameplay _gameplay;
+        private readonly GameLoop _gameLoop;
+        private readonly SelectionHandler _selectionHandler;
+        private readonly IGameStateStore? _stateStore;
+        private bool _configured;
+        private bool _disposed;
+
+        internal GameApplication(GameSession session, BaseGameplay gameplay, GameLoop gameLoop, SelectionHandler selectionHandler, IGameStateStore? stateStore)
+        {
+            _session = session;
+            _gameplay = gameplay;
+            _gameLoop = gameLoop;
+            _selectionHandler = selectionHandler;
+            _stateStore = stateStore;
+        }
+
+        public GameSession Session => _session;
+
+        public BaseGameplay Gameplay => _gameplay;
+
+        public GameLoop GameLoop => _gameLoop;
+
+        public SelectionHandler SelectionHandler => _selectionHandler;
+
+        public void Configure()
+        {
+            if (_configured)
+            {
+                return;
+            }
+
+            _gameplay.RegisterGameLoop(_gameLoop);
+            _gameLoop.RegisterSelectionHandler(_selectionHandler);
+            _selectionHandler.RegisterMenu(RunMenu);
+
+            _configured = true;
+        }
+
+        public void Run()
+        {
+            if (!_configured)
+            {
+                Configure();
+            }
+
+            _gameplay.Setup();
+            RunMenu();
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            if (disposing)
+            {
+                PersistState();
+                _session.Dispose();
+            }
+
+            _disposed = true;
+        }
+
+        private void RunMenu()
+        {
+            var menu = new Menu(_session, _gameplay, _gameLoop, _selectionHandler);
+            menu.Run();
+            PersistState();
+        }
+
+        private void PersistState()
+        {
+            if (_stateStore == null)
+            {
+                return;
+            }
+
+            var playerData = _session.CapturePlayerState();
+            _stateStore.SavePlayer(playerData);
+        }
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -1,8 +1,5 @@
-using GameplayNamespace;
-using Handlers;
-using LabyrinthExplorer.Gameplay;
-using LabyrinthExplorer.Handlers;
-using LabyrinthExplorer.Utilities;
+using System;
+using LabyrinthExplorer.Infrastructure;
 
 namespace LabyrinthExplorer
 {
@@ -10,25 +7,35 @@ namespace LabyrinthExplorer
     {
         static void Main(string[] args)
         {
-            var console = new SystemConsoleService();
-            var session = GameSession.CreateDefault(console: console);
-
-            var gameplay = new BaseGameplay(session);
-            var gameLoop = new GameLoop(session, gameplay);
-            var selectionHandler = new SelectionHandler(session, gameplay, gameLoop);
-
-            gameplay.RegisterGameLoop(gameLoop);
-            gameLoop.RegisterSelectionHandler(selectionHandler);
-            selectionHandler.RegisterMenu(() =>
+            try
             {
-                var menuFromGame = new Menu(session, gameplay, gameLoop, selectionHandler);
-                menuFromGame.Run();
-            });
+                var options = ParseArguments(args);
+                using var application = GameBuilder.Build(options);
+                application.Run();
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"An error occurred while starting the game: {ex.Message}");
+            }
+        }
 
-            gameplay.Setup();
+        private static GameBuilderOptions ParseArguments(string[] args)
+        {
+            var options = new GameBuilderOptions();
 
-            var menu = new Menu(session, gameplay, gameLoop, selectionHandler);
-            menu.Run();
+            for (int i = 0; i < args.Length; i++)
+            {
+                if (args[i].Equals("--seed", StringComparison.OrdinalIgnoreCase) && i + 1 < args.Length)
+                {
+                    if (int.TryParse(args[i + 1], out var seed))
+                    {
+                        options.Seed = seed;
+                        i++;
+                    }
+                }
+            }
+
+            return options;
         }
     }
 }

--- a/Utilities/IGameStateStore.cs
+++ b/Utilities/IGameStateStore.cs
@@ -1,0 +1,9 @@
+namespace LabyrinthExplorer
+{
+    public interface IGameStateStore
+    {
+        PlayerData? LoadPlayer();
+
+        void SavePlayer(PlayerData playerData);
+    }
+}


### PR DESCRIPTION
## Summary
- introduce a GameBuilder/GameApplication pair to assemble gameplay dependencies and menu wiring
- add options for overriding console, random provider seed, and persistence via a game state store
- simplify Program.Main to parse arguments and launch the composed game graph

## Testing
- Not run (dotnet CLI unavailable in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6944749d461c83328af28dcad73c0483)