### PR TITLE
Refactor player mapping and notifications

### DIFF
--- a/Gameplay/GameSession.cs
+++ b/Gameplay/GameSession.cs
@@ -7,11 +7,18 @@ namespace LabyrinthExplorer.Gameplay
     {
         private bool _disposed;
 
-        public GameSession(IConsoleService consoleService, IRandomProvider? randomProvider = null, PlayerData? playerData = null)
+        public GameSession(
+            IConsoleService consoleService,
+            IRandomProvider? randomProvider = null,
+            PlayerData? playerData = null,
+            IPlayerObserver? playerObserver = null,
+            IPlayerStateMapper? playerStateMapper = null)
         {
             Console = consoleService;
             RandomProvider = randomProvider ?? new RandomProvider();
-            Player = new Player(Console, playerData ?? new PlayerData());
+            var mapper = playerStateMapper ?? new PlayerStateMapper();
+            var observer = playerObserver ?? new ConsolePlayerObserver(Console);
+            Player = new Player(mapper, observer, playerData ?? new PlayerData());
             GameplayData = new GameplayData();
         }
 

--- a/IPlayerObserver.cs
+++ b/IPlayerObserver.cs
@@ -1,0 +1,43 @@
+using System;
+using LabyrinthExplorer.Utilities;
+
+namespace LabyrinthExplorer
+{
+    public interface IPlayerObserver
+    {
+        void OnSanityChanged(Player player, int sanity);
+
+        void OnInventoryItemShown(Item item);
+    }
+
+    public class NullPlayerObserver : IPlayerObserver
+    {
+        public void OnSanityChanged(Player player, int sanity)
+        {
+        }
+
+        public void OnInventoryItemShown(Item item)
+        {
+        }
+    }
+
+    public class ConsolePlayerObserver : IPlayerObserver
+    {
+        private readonly IConsoleService _console;
+
+        public ConsolePlayerObserver(IConsoleService console)
+        {
+            _console = console ?? throw new ArgumentNullException(nameof(console));
+        }
+
+        public void OnSanityChanged(Player player, int sanity)
+        {
+            _console.Write($"Sanity changed to: {sanity}");
+        }
+
+        public void OnInventoryItemShown(Item item)
+        {
+            _console.Write($"[ {item.Name} ] ");
+        }
+    }
+}

--- a/LabyrinthExplorer.Tests/PlayerObserverTests.cs
+++ b/LabyrinthExplorer.Tests/PlayerObserverTests.cs
@@ -1,0 +1,39 @@
+using LabyrinthExplorer.Data;
+using LabyrinthExplorer.Tests.TestUtilities;
+using Xunit;
+
+namespace LabyrinthExplorer.Tests
+{
+    public class PlayerObserverTests
+    {
+        [Fact]
+        public void SanityChanges_NotifyObserver()
+        {
+            var mapper = new PlayerStateMapper();
+            var observer = new RecordingPlayerObserver();
+            var player = new Player(mapper, observer, new PlayerData());
+
+            player.Sanity = 12;
+            player.Sanity = 15;
+
+            Assert.Collection(observer.SanityChanges,
+                change => Assert.Equal(12, change),
+                change => Assert.Equal(15, change));
+        }
+
+        [Fact]
+        public void ShowInventory_RelaysItemsToObserver()
+        {
+            var mapper = new PlayerStateMapper();
+            var observer = new RecordingPlayerObserver();
+            var player = new Player(mapper, observer, new PlayerData());
+            var item = new Item { Name = "Gem" };
+            player.Inventory.Add(item);
+
+            player.ShowInventory();
+
+            Assert.Single(observer.InventoryShown);
+            Assert.Equal(item, observer.InventoryShown[0]);
+        }
+    }
+}

--- a/LabyrinthExplorer.Tests/PlayerStateMapperTests.cs
+++ b/LabyrinthExplorer.Tests/PlayerStateMapperTests.cs
@@ -1,0 +1,63 @@
+using System.Linq;
+using LabyrinthExplorer.Data;
+using LabyrinthExplorer.Tests.TestUtilities;
+using Xunit;
+
+namespace LabyrinthExplorer.Tests
+{
+    public class PlayerStateMapperTests
+    {
+        [Fact]
+        public void ToData_CreatesDeepCopyOfInventory()
+        {
+            var mapper = new PlayerStateMapper();
+            var observer = new RecordingPlayerObserver();
+            var player = new Player(mapper, observer, new PlayerData())
+            {
+                Name = "Explorer",
+                Sanity = 8,
+            };
+            player.Inventory.Add(new Card { Name = "Torch", Description = "Bright light" });
+            player.Inventory.Add(new Weapon { Name = "Sword", Description = "Sharp" });
+
+            var data = mapper.ToData(player);
+
+            Assert.Equal("Explorer", data.Name);
+            Assert.Equal(8, data.Sanity);
+            Assert.Equal(2, data.Inventory.Count);
+
+            player.Inventory[0].Name = "Changed";
+
+            var mappedNames = data.Inventory.Select(i => i.Name).ToList();
+            Assert.Contains("Torch", mappedNames);
+            Assert.Contains("Sword", mappedNames);
+        }
+
+        [Fact]
+        public void Apply_RestoresStateWithoutSharingInventoryInstances()
+        {
+            var mapper = new PlayerStateMapper();
+            var observer = new RecordingPlayerObserver();
+            var player = new Player(mapper, observer, new PlayerData());
+            var data = new PlayerData
+            {
+                Name = "NewName",
+                Sanity = 3,
+                Inventory =
+                {
+                    new Card { Name = "Map", Description = "Guidance" },
+                }
+            };
+
+            mapper.Apply(player, data);
+
+            Assert.Equal("NewName", player.Name);
+            Assert.Equal(3, player.Sanity);
+            Assert.Single(player.Inventory);
+
+            data.Inventory[0].Name = "Changed";
+
+            Assert.Equal("Map", player.Inventory[0].Name);
+        }
+    }
+}

--- a/LabyrinthExplorer.Tests/TestUtilities/RecordingPlayerObserver.cs
+++ b/LabyrinthExplorer.Tests/TestUtilities/RecordingPlayerObserver.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+using LabyrinthExplorer.Data;
+
+namespace LabyrinthExplorer.Tests.TestUtilities
+{
+    public class RecordingPlayerObserver : IPlayerObserver
+    {
+        public List<int> SanityChanges { get; } = new();
+
+        public List<Item> InventoryShown { get; } = new();
+
+        public void OnSanityChanged(Player player, int sanity)
+        {
+            SanityChanges.Add(sanity);
+        }
+
+        public void OnInventoryItemShown(Item item)
+        {
+            InventoryShown.Add(item);
+        }
+    }
+}

--- a/Player.cs
+++ b/Player.cs
@@ -9,18 +9,25 @@ namespace LabyrinthExplorer
 {
     public class Player : IDisposable
     {
-        private readonly IConsoleService _console;
+        private readonly IPlayerStateMapper _stateMapper;
+        private readonly IPlayerObserver _observer;
         private readonly Notifier<int> _Sanity = new Notifier<int>();
         private bool _disposed;
 
         public Player(IConsoleService console)
-            : this(console, new PlayerData())
+            : this(new PlayerStateMapper(), new ConsolePlayerObserver(console), new PlayerData())
         {
         }
 
         public Player(IConsoleService console, PlayerData state)
+            : this(new PlayerStateMapper(), new ConsolePlayerObserver(console), state)
         {
-            _console = console;
+        }
+
+        public Player(IPlayerStateMapper stateMapper, IPlayerObserver observer, PlayerData state)
+        {
+            _stateMapper = stateMapper ?? throw new ArgumentNullException(nameof(stateMapper));
+            _observer = observer ?? throw new ArgumentNullException(nameof(observer));
             _Sanity.PropertyChanged += Score_PropertyChanged;
             Inventory = new List<Item>();
 
@@ -37,92 +44,37 @@ namespace LabyrinthExplorer
 
         public List<Item> Inventory { get; private set; }
 
-        public PlayerData ToData()
-        {
-            return new PlayerData
-            {
-                Name = Name,
-                Sanity = Sanity,
-                Inventory = CloneInventory()
-            };
-        }
+        public PlayerData ToData() => _stateMapper.ToData(this);
 
         public void LoadFromData(PlayerData state)
         {
-            if (state == null)
-            {
-                throw new ArgumentNullException(nameof(state));
-            }
-
-            Name = state.Name ?? string.Empty;
-            ReplaceInventory(state.Inventory ?? new List<Item>());
-            SetSanitySilently(state.Sanity);
+            _stateMapper.Apply(this, state);
         }
 
         private void Score_PropertyChanged(object sender, PropertyChangedEventArgs e)
         {
-            _console.Write($"Sanity changed to: {Sanity}");
+            _observer.OnSanityChanged(this, Sanity);
         }
 
-        private void SetSanitySilently(int sanity)
+        internal void SetSanitySilently(int sanity)
         {
             _Sanity.PropertyChanged -= Score_PropertyChanged;
             _Sanity.Prop = sanity;
             _Sanity.PropertyChanged += Score_PropertyChanged;
         }
-
-        private List<Item> CloneInventory()
-        {
-            var clone = new List<Item>();
-
-            foreach (var item in Inventory)
-            {
-                clone.Add(CloneItem(item));
-            }
-
-            return clone;
-        }
-
-        private static Item CloneItem(Item item)
-        {
-            return item switch
-            {
-                Card card => new Card
-                {
-                    _CardType = card._CardType,
-                    Name = card.Name,
-                    Description = card.Description,
-                    ID = card.ID
-                },
-                Weapon weapon => new Weapon
-                {
-                    _WeaponType = weapon._WeaponType,
-                    Name = weapon.Name,
-                    Description = weapon.Description,
-                    ID = weapon.ID
-                },
-                _ => new Item
-                {
-                    Name = item.Name,
-                    Description = item.Description,
-                    ID = item.ID
-                }
-            };
-        }
-
-        private void ReplaceInventory(IEnumerable<Item> items)
+        internal void ReplaceInventory(IEnumerable<Item> items)
         {
             Inventory = new List<Item>();
 
             foreach (var item in items)
             {
-                Inventory.Add(CloneItem(item));
+                Inventory.Add(item);
             }
         }
 
         public void ShowInventory()
         {
-            Inventory.ForEach(item => _console.Write($"[ {item.Name} ] "));
+            Inventory.ForEach(item => _observer.OnInventoryItemShown(item));
         }
 
         public override string ToString()

--- a/PlayerStateMapper.cs
+++ b/PlayerStateMapper.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Collections.Generic;
+using LabyrinthExplorer.Data;
+
+namespace LabyrinthExplorer
+{
+    public interface IPlayerStateMapper
+    {
+        PlayerData ToData(Player player);
+
+        void Apply(Player player, PlayerData state);
+    }
+
+    public class PlayerStateMapper : IPlayerStateMapper
+    {
+        public PlayerData ToData(Player player)
+        {
+            if (player == null)
+            {
+                throw new ArgumentNullException(nameof(player));
+            }
+
+            return new PlayerData
+            {
+                Name = player.Name,
+                Sanity = player.Sanity,
+                Inventory = CloneInventory(player.Inventory)
+            };
+        }
+
+        public void Apply(Player player, PlayerData state)
+        {
+            if (player == null)
+            {
+                throw new ArgumentNullException(nameof(player));
+            }
+
+            if (state == null)
+            {
+                throw new ArgumentNullException(nameof(state));
+            }
+
+            player.Name = state.Name ?? string.Empty;
+            player.ReplaceInventory(CloneInventory(state.Inventory ?? new List<Item>()));
+            player.SetSanitySilently(state.Sanity);
+        }
+
+        private static List<Item> CloneInventory(IEnumerable<Item> items)
+        {
+            var clone = new List<Item>();
+
+            foreach (var item in items)
+            {
+                clone.Add(CloneItem(item));
+            }
+
+            return clone;
+        }
+
+        private static Item CloneItem(Item item)
+        {
+            return item switch
+            {
+                Card card => new Card
+                {
+                    _CardType = card._CardType,
+                    Name = card.Name,
+                    Description = card.Description,
+                    ID = card.ID
+                },
+                Weapon weapon => new Weapon
+                {
+                    _WeaponType = weapon._WeaponType,
+                    Name = weapon.Name,
+                    Description = weapon.Description,
+                    ID = weapon.ID
+                },
+                _ => new Item
+                {
+                    Name = item.Name,
+                    Description = item.Description,
+                    ID = item.ID
+                }
+            };
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a PlayerStateMapper to map between Player and PlayerData with deep inventory copies
- route player notifications through an observer interface instead of direct console writes
- add unit tests covering the mapper and observer behaviors

## Testing
- `dotnet test` *(fails: dotnet not available in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69447d62cf848332951203954bb071f2)